### PR TITLE
Fix Branch Names section of contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,9 +18,9 @@ Commit messages start with a captial letter. The first word should be a verb to 
 
 ## Branch naming
 
-Branch names start with verbs to represent what the main intention is. For example, a branch intended to add a new feature would be `create-new-feature`. Other verbs include `add`, `refactor`, `change`, `fix`, `remove` and `delete`.
+Branch names start with either `feature` or `hotfix`, which reflect the intention of the branch. For example, a branch intended to perform a hotfix is named `hotfix/something-terribly-wrong`.
 
-Additionally, if the branch only concerns a single package, the branch name should be preceded with the package that the branch is intended for. For example, branches that work on the `api` package should be named `api/branch-name`. For branches that concern the repository in general, the branch name should remain as is.
+Additionally, if the branch only concerns a single package, the branch intention should be succeeded with the package that the branch is intended for. For example, branches that work on the `api` package should be named `feature/api/cool-new-feature`.
 
 ## Code of Conduct
 


### PR DESCRIPTION
During the feedback fixes in #4, I forgot to change the Branch Names section in the contributing guide. This hotfix fixes the section.

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
