### PR TITLE
Change to explicit Fragment usage instead of special JSX

### DIFF
--- a/src/app/pages/index.tsx
+++ b/src/app/pages/index.tsx
@@ -1,12 +1,12 @@
-import { Component } from "react";
+import { Component, Fragment } from "react";
 
 export default class extends Component {
   public render() {
     return (
-      <>
+      <Fragment>
         <h1>The White Line</h1>
         <h3>Learn because you want to</h3>
-      </>
+      </Fragment>
     );
   }
 }


### PR DESCRIPTION
As mentioned in #8, the empty tag JSX syntax for `Fragment`s is harmful to the code. This PR removed its usage.

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
